### PR TITLE
Fix compatibily issue with Allegro CL Modern mode

### DIFF
--- a/t/test-values
+++ b/t/test-values
@@ -1,1 +1,1 @@
-(:PCODE 1 (:HASH-TABLE 1 16 1.5 1.0 EQUALP NIL (:TWO (:LIST 2 2 2))))
+(:pcode 1 (:hash-table 1 16 1.5 1.0 equalp nil (:two (:list 2 2 2))))


### PR DESCRIPTION
Change symbols to lower case, this trivial change allow the tests to run successfully under Allegro CL Modern mode (see http://franz.com/support/documentation/current/doc/case.htm).

Tested with

- Allegro CL 10.1 ANSI and Modern modes
- SBCL 1.3.18