### PR TITLE
fixing CONTROL-ERROR in RESTART-CASE for impls ALLEGRO, CCL, CLISP

### DIFF
--- a/checkl.lisp
+++ b/checkl.lisp
@@ -97,14 +97,18 @@ OBJECT)) is called."))
                    (return-from verify-result result))
         (use-new-value ()
           :report "The new value is correct, use it from now on."
-          :test (lambda (c) (typep c 'result-error))
+          :test
+	  #-(or allegro ccl clisp) (lambda (c) (typep c 'result-error))
+	  #+(or allegro ccl clisp) (lambda (c) (or (null c) (typep c 'result-error)))
           (incf index-base (1+ result-index))
           (setf (nth result-index last-result) result-value)
           (setf cur-result (nthcdr (1+ result-index) cur-result))
           (setf last-result (nthcdr (1+ result-index) last-result)))
         (skip-test ()
           :report "Skip this, leaving the old value, but continue testing"
-          :test (lambda (c) (typep c 'result-error))
+	  :test
+          #-(or allegro ccl clisp) (lambda (c) (typep c 'result-error))
+	  #+(or allegro ccl clisp) (lambda (c) (or (null c) (typep c 'result-error)))
           (incf index-base (1+ result-index))
           (setf cur-result (nthcdr (1+ result-index) cur-result))
           (setf last-result (nthcdr (1+ result-index) last-result))


### PR DESCRIPTION
Restarts use-new-value and skip-test are not considered 'active' by,
for instance, Allegro; that is, they signal a CONTROL-ERROR "restart
... not active," and as a result don't work as intended.  On the
Openmcl-devel mailing list, Gary Byers gave an explanation of this
behavior in response to a post by Stelian Onescu:

"Some implementations (LispWorks and SBCL) that I looked at appear to
consider inapplicable restarts to be valid; others (Allegro, CLISP,
and CCL) don't."[1]

Following the "somewhat awkward idiom" he suggests, this change uses a
different :test on those implementations which returns t for the input
value nil.

Reference:

[1]

[Openmcl-devel] INVOKE-RESTART bug
Gary Byers gb at clozure.com
Thu Jun 3 11:24:52 UTC 2010

https://lists.clozure.com/pipermail/openmcl-devel/2010-June/007374.html